### PR TITLE
Shio end-to-end test routines

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,6 +1,28 @@
 # ocm-minikube-ramen.sh
 
-Ramen end-to-end test script
+## minikube-ramen.sh
+
+Ramen dr-cluster end-to-end test script
+
+- cluster names are specified with the `cluster_names` variable
+    - `cluster1` and `cluster2` by default
+- application sample namespace name is specified with the `application_sample_namespace_name`
+  variable
+    - `default` by default
+- takes a list of functions to execute:
+    - `deploy` (default) deploys the environment including:
+      minikube clusters, rook-ceph, minio s3 stores, ramen
+    - `undeploy` undeploys the things deployed by `deploy`
+    - `manager_redeploy` rebuilds and redeploys ramen manager
+    - `application_sample_deploy` deploys busybox-sample app to specified cluster
+    - `application_sample_undeploy` undeploys busybox-sample app from specified cluster
+    - `application_sample_vrg_deploy` deploys busybox-sample app vrg to 1st cluster
+    - `application_sample_vrg_undeploy` undeploys busybox-sample app vrg from 1st
+      cluster
+
+## ocm-minikube-ramen.sh
+
+open-cluster-management Ramen end-to-end test script
 
 - can be run from any directory; writes temporary files to /tmp
 - installs some dependencies (e.g. minikube, golang, etc), but not necessarily

--- a/hack/minikube-ramen.sh
+++ b/hack/minikube-ramen.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# shellcheck disable=2086
+set -e
+ramen_hack_directory_path_name=$(dirname $0)
+cluster_names=${cluster_names:-cluster1\ cluster2}
+deploy()
+{
+	spoke_cluster_names=$cluster_names $ramen_hack_directory_path_name/ocm-minikube.sh minikube_start_spokes
+	spoke_cluster_names=$cluster_names $ramen_hack_directory_path_name/ocm-minikube-ramen.sh\
+		rook_ceph_deploy\
+		minio_deploy_spokes\
+		ramen_manager_image_build_and_archive\
+		ramen_deploy_spokes\
+
+}
+undeploy()
+{
+	spoke_cluster_names=$cluster_names $ramen_hack_directory_path_name/ocm-minikube-ramen.sh\
+		ramen_undeploy_spokes\
+		minio_undeploy_spokes\
+		rook_ceph_undeploy\
+
+}
+manager_redeploy()
+{
+	spoke_cluster_names=$cluster_names $ramen_hack_directory_path_name/ocm-minikube-ramen.sh\
+		ramen_undeploy_spokes\
+		ramen_manager_image_build_and_archive\
+		ramen_deploy_spokes\
+
+	for cluster_name in $cluster_names; do
+		minikube -p $cluster_name ssh -- docker images\|grep ramen
+	done; unset -v cluster_name
+}
+application_sample_namespace_name=${application_sample_namespace_name:-default}
+application_sample_namespace_deploy()
+{
+	kubectl create namespace $application_sample_namespace_name --dry-run=client -oyaml|kubectl --context $1 apply -f-
+}
+application_sample_namespace_undeploy()
+{
+	kubectl --context $1 delete namespace $application_sample_namespace_name
+}
+application_sample_kubectl()
+{
+	kubectl --context $1 -n$application_sample_namespace_name $2 -khttps://github.com/RamenDR/ocm-ramen-samples/busybox
+}
+application_sample_deploy()
+{
+	application_sample_kubectl $1 apply
+}
+application_sample_undeploy()
+{
+	application_sample_kubectl $1 delete
+}
+application_sample_vrg_kubectl()
+{
+	cat <<-a|kubectl --context $1 -n$application_sample_namespace_name $2 -f-
+	---
+	apiVersion: ramendr.openshift.io/v1alpha1
+	kind: VolumeReplicationGroup
+	metadata:
+	  name: bb
+	spec:
+	  async:
+	    mode: Enabled
+	    replicationClassSelector: {}
+	    schedulingInterval: 1m
+	  pvcSelector:
+	    matchLabels:
+	      appname: busybox
+	  replicationState: primary
+	  s3Profiles:
+$(for cluster_name in $cluster_names; do echo \ \ -\ minio-on-$cluster_name; done; unset -v cluster_name)
+	  sync:
+	    mode: Disabled$vrg_appendix
+	a
+}
+application_sample_vrg_deploy()
+{
+	application_sample_vrg_kubectl $1 apply\ -oyaml
+}
+application_sample_vrg_undeploy()
+{
+	application_sample_vrg_kubectl $1 delete\ --ignore-not-found
+}
+set -x
+for command in "${@:-deploy}"; do
+	$command
+done
+{ set +x; } 2>/dev/null
+unset -v command
+unset -f application_sample_vrg_undeploy
+unset -f application_sample_vrg_deploy
+unset -f application_sample_vrg_kubectl
+unset -f application_sample_undeploy
+unset -f application_sample_deploy
+unset -f application_sample_kubectl
+unset -f application_sample_namespace_undeploy
+unset -f application_sample_namespace_deploy
+unset -v application_sample_namespace_name
+unset -f manager_redeploy
+unset -f undeploy
+unset -f deploy
+unset -v cluster_names
+unset -v ramen_hack_directory_path_name

--- a/hack/minikube.sh
+++ b/hack/minikube.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# shellcheck disable=2086
+minikube_minio_url()
+{
+	minikube --profile $1 -n minio service --url minio
+}
+minikube_unset()
+{
+	unset -f minikube_unset
+	unset -f minikube_minio_url
+}

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -10,6 +10,8 @@ exit_stack_push unset -f true_if_exit_status_and_stderr
 exit_stack_push unset -f until_true_or_n
 . $ramen_hack_directory_path_name/olm.sh
 exit_stack_push olm_unset
+. $ramen_hack_directory_path_name/minikube.sh
+exit_stack_push minikube_unset
 exit_stack_push unset -v ramen_hack_directory_path_name
 rook_ceph_deploy_spoke()
 {
@@ -498,14 +500,14 @@ ramen_config_deploy_hub_or_spoke()
 	s3StoreProfiles:
 	- s3ProfileName: minio-on-$4
 	  s3Bucket: bucket
-	  s3CompatibleEndpoint: $(minikube --profile $4 -n minio service --url minio)
+	  s3CompatibleEndpoint: $(minikube_minio_url $4)
 	  s3Region: us-east-1
 	  s3SecretRef:
 	    name: s3secret
 	    namespace: ramen-system
 	- s3ProfileName: minio-on-$5
 	  s3Bucket: bucket
-	  s3CompatibleEndpoint: $(minikube --profile $5 -n minio service --url minio)
+	  s3CompatibleEndpoint: $(minikube_minio_url $5)
 	  s3Region: us-west-1
 	  s3SecretRef:
 	    name: s3secret

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -1,82 +1,150 @@
 #!/bin/sh
+# shellcheck disable=1090,2046,2086
+set -e
 
-# Infra deploy
-hack/minikube-ramen.sh deploy
-hack/velero-test.sh velero_deploy\ cluster1
-hack/velero-test.sh velero_deploy\ cluster2
-kubectl --context cluster1 -nvelero create secret generic s3secret --from-literal aws='[default]
-aws_access_key_id=minio
-aws_secret_access_key=minio123
-'
-kubectl --context cluster2 -nvelero create secret generic s3secret --from-literal aws='[default]
-aws_access_key_id=minio
-aws_secret_access_key=minio123
-'
+ramen_hack_directory_path_name=$(dirname $0)
+. $ramen_hack_directory_path_name/exit_stack.sh
+exit_stack_push unset -v ramen_hack_directory_path_name
+. $ramen_hack_directory_path_name/minikube.sh; exit_stack_push minikube_unset
+. $ramen_hack_directory_path_name/true_if_exit_status_and_stderr.sh; exit_stack_push unset -f true_if_exit_status_and_stderr
 
+infra_deploy() {
+$ramen_hack_directory_path_name/minikube-ramen.sh deploy
 minikube profile list
+$ramen_hack_directory_path_name/velero-test.sh velero_deploy\ cluster1
+$ramen_hack_directory_path_name/velero-test.sh velero_deploy\ cluster2
+velero_secret_deploy cluster1
+velero_secret_deploy cluster2
+kubectl --context cluster1 -nvelero get bsl,backup,restore
+kubectl --context cluster2 -nvelero get bsl,backup,restore
+	mc alias set cluster2 $(minikube_minio_url cluster2) minio minio123
+mc tree cluster2
+}; exit_stack_push unset -f infra_deploy
 
-# App deploy
+infra_undeploy() {
+	velero_secret_undeploy cluster2
+	velero_secret_undeploy cluster1
+	$ramen_hack_directory_path_name/minikube-ramen.sh undeploy
+}; exit_stack_push unset -f infra_undeploy
+
+velero_secret_kubectl() {
+	kubectl create secret generic s3secret --from-literal aws='[default]
+aws_access_key_id=minio
+aws_secret_access_key=minio123
+' --dry-run=client -oyaml|kubectl --context $1 -nvelero $2 -f-
+}; exit_stack_push unset -f velero_secret_kubectl
+
+velero_secret_deploy() {
+	velero_secret_kubectl $1 apply
+}; exit_stack_push unset -f velero_secret_deploy
+
+velero_secret_undeploy() {
+	velero_secret_kubectl $1 delete\ --ignore-not-found
+}; exit_stack_push unset -f velero_secret_undeploy
+
+app_deploy() {
 kubectl --context cluster1        create namespace asdf
 kubectl --context cluster1 -nasdf create configmap asdf
 kubectl --context cluster1 -nasdf create secret generic asdf --from-literal=key1=value1
 kubectl --context cluster1 -nasdf create deploy asdf --image busybox -- sh -c while\ true\;do\ date\;sleep\ 60\;done
 kubectl --context cluster1 -nasdf create -k https://github.com/RamenDR/ocm-ramen-samples/busybox
-kubectl --context cluster1 -nasdf get cm,secret,deploy,rs,po,pvc
+	app_kube_objects_list cluster1
+}; exit_stack_push unset -f app_deploy
 
-kubectl --context cluster1 -nvelero get deploy/velero
-kubectl --context cluster1 -nvelero get secret/s3secret -oyaml
+app_kube_object_list() {
+kubectl --context $1 -nasdf get cm,secret,deploy,rs,po,pvc
+}; exit_stack_push unset -f app_kube_objects_list
 
-# Clean?
-kubectl --context cluster1 -nvelero get bsl,backup,restore
-kubectl --context cluster2 -nvelero get bsl,backup,restore
-mc tree cluster2
-kubectl --context cluster2          get ns/asdf
+app_undeploy() {
+kubectl --context $1        delete namespace asdf&
+	vrg_finalizer0_remove $1
+wait
+}; exit_stack_push unset -f app_undeploy
 
-# Protect
-hack/minikube-ramen.sh eval\ application_sample_vrg_kubectl\ cluster1\ cluster2\ asdf\ create\\\ -oyaml
+vrg_deploy() {
+	vrg_appendix='
+  kubeObjectProtection: {}'\
+	vrg_appendix='
+  kubeObjectProtection:
+    captureFrequency: 3m'\
+	cluster_names=cluster2 application_sample_namespace_name=asdf $ramen_hack_directory_path_name/minikube-ramen.sh  application_sample_vrg_deploy\ $1
+}; exit_stack_push unset -f vrg_deploy
+
+vrg_finalizer0_remove() {
+	true_if_exit_status_and_stderr 1 'Error from server (NotFound): volumereplicationgroups.ramendr.openshift.io "bb" not found' \
+	kubectl --context $1 -nasdf patch vrg/bb --type json -p '[{"op":remove, "path":/metadata/finalizers/0}]'
+}; exit_stack_push unset -f vrg_finalizer0_remove
+
+vrg_get() {
+	kubectl --context $1 -nasdf get vrg/bb -oyaml --ignore-not-found
+}; exit_stack_push unset -f vrg_get
+
+app_protect() {
+	vrg_deploy cluster1
+	vrg_get cluster1
 time kubectl --context cluster1 -nasdf wait vrg/bb --for condition=clusterdataprotected --timeout 2m
-mc tree cluster2
-mc cp -q cluster2/bucket/asdf/bb/backups/a/a-resource-list.json.gz /tmp;gzip -df /tmp/a-resource-list.json.gz;python -m json.tool </tmp/a-resource-list.json
+	app_protection_info 0
+}; exit_stack_push unset -f app_protect
 
-# Recover
+app_unprotect() {
+	cluster_names=cluster2 application_sample_namespace_name=asdf $ramen_hack_directory_path_name/minikube-ramen.sh application_sample_vrg_undeploy\ $1&
+	vrg_finalizer0_remove $1
+	wait
+	kubectl --context $1 -nasdf delete events --all
+}; exit_stack_push unset -f app_unprotect
+
+app_recover() {
 kubectl --context cluster2        create namespace asdf
-hack/minikube-ramen.sh eval\ application_sample_vrg_kubectl\ cluster2\ cluster1\ asdf\ create\\\ -oyaml
+	vrg_deploy cluster2
 time kubectl --context cluster2 -nasdf wait vrg/bb --for condition=clusterdataready --timeout 2m
-kubectl --context cluster2 -nasdf get cm,secret,deploy,rs,po,pvc
+	app_kube_objects_list cluster2
+}; exit_stack_push unset -f app_recover
 
-
-
-
-
-
-
-
-
-mc cp -q cluster2/bucket/asdf/bb/restores/a/restore-a-results.gz /tmp;gzip -df /tmp/restore-a-results.gz;python -m json.tool </tmp/restore-a-results
-mc cp -q cluster2/bucket/asdf/bb/restores/a/restore-a-logs.gz /tmp;gzip -df /tmp/restore-a-logs.gz; cat /tmp/restore-a-logs
-
-# App cleanup
-kubectl --context cluster1 -nasdf delete -fhack/vrg.yaml
-kubectl --context cluster1 -nasdf patch vrg/bb --type json -p '[{"op":remove, "path":/metadata/finalizers/0}]'
-kubectl --context cluster1 -nasdf delete events --all
-kubectl --context cluster2        delete namespace asdf
-kubectl --context cluster2 -nasdf patch vrg/bb --type json -p '[{"op":remove, "path":/metadata/finalizers/0}]'
-velero --kubecontext cluster1 delete --all --confirm backups
-velero --kubecontext cluster1 delete --all --confirm backup-locations
-velero --kubecontext cluster1 delete --all --confirm restores
-velero --kubecontext cluster2 delete --all --confirm backups
-velero --kubecontext cluster2 delete --all --confirm backup-locations
-velero --kubecontext cluster2 delete --all --confirm restores
-velero --kubecontext cluster1 get backups
-velero --kubecontext cluster1 get backup-locations
-velero --kubecontext cluster1 get restores
-velero --kubecontext cluster2 get backups
-velero --kubecontext cluster2 get backup-locations
-velero --kubecontext cluster2 get restores
+s3_objects_list() {
 mc tree cluster2
-mc rm cluster2/bucket/asdf/bb/ --recursive --force
+mc ls cluster2 --recursive
+}; exit_stack_push unset -f s3_objects_list
 
-# Infra cleanup
-kubectl --context cluster1 -nvelero delete secret s3secret
-kubectl --context cluster2 -nvelero delete secret s3secret
-hack/minikube-ramen.sh undeploy
+app_s3_object_name_prefix() {
+	echo cluster2/bucket/asdf/bb/
+}; exit_stack_push unset -f app_s3_object_name_prefix
+
+app_s3_object_name_prefix_velero() {
+	echo $(app_s3_object_name_prefix)velero/
+}; exit_stack_push unset -f app_s3_object_name_prefix_velero
+
+app_s3_objects_delete() {
+	s3_objects_name
+mc rm $(app_s3_object_name_prefix) --recursive --force
+}; exit_stack_push unset -f app_objects_delete
+
+app_protection_info() {
+mc cp -q $(app_s3_object_name_prefix_velero)backups/$1/$1-resource-list.json.gz /tmp;gzip -df /tmp/$1-resource-list.json.gz;python -m json.tool </tmp/$1-resource-list.json
+mc cp -q $(app_s3_object_name_prefix_velero)backups/$1/$1-logs.gz /tmp;gzip -df /tmp/$1-logs.gz;cat /tmp/$1-logs
+}; exit_stack_push unset -f app_protection_info
+
+app_recovery_info() {
+mc cp -q $(app_s3_object_name_prefix_velero)restores/$1/restore-$1-results.gz /tmp;gzip -df /tmp/restore-$1-results.gz;python -m json.tool </tmp/restore-$1-results
+mc cp -q $(app_s3_object_name_prefix_velero)restores/$1/restore-$1-logs.gz /tmp;gzip -df /tmp/restore-$1-logs.gz;cat /tmp/restore-$1-logs
+}; exit_stack_push unset -f app_recovery_info
+
+velero_kube_objects_list() {
+velero --kubecontext $1 get backups
+velero --kubecontext $1 get backup-locations
+velero --kubecontext $1 get restores
+}; exit_stack_push unset -f velero_kube_objects_list
+
+velero_kube_objects_undeploy() {
+velero_kube_objects_list $1
+velero --kubecontext $1 delete --all --confirm backups
+velero --kubecontext $1 delete --all --confirm backup-locations
+velero --kubecontext $1 delete --all --confirm restores
+velero_kube_objects_list $1
+}; exit_stack_push unset -f velero_kube_objects_undeploy
+
+exit_stack_push unset -v command
+set -x
+for command in "${@:-infra_deploy app_deploy app_protect}"; do
+	$command
+done
+{ set +x;} 2>/dev/null

--- a/hack/velero-test.sh
+++ b/hack/velero-test.sh
@@ -2,6 +2,10 @@
 # shellcheck disable=1090,2046,2086
 set -e
 ramen_hack_directory_path_name=$(dirname $0)
+. $ramen_hack_directory_path_name/exit_stack.sh
+exit_stack_push unset -v ramen_hack_directory_path_name
+. $ramen_hack_directory_path_name/minikube.sh
+exit_stack_push minikube_unset
 velero_directory_path_name=~/.local/bin
 
 . $ramen_hack_directory_path_name/until_true_or_n.sh
@@ -71,10 +75,6 @@ velero_undeploy()
 minio_deploy()
 {
 	$ramen_hack_directory_path_name/ocm-minikube-ramen.sh rook_ceph_deploy_spoke\ $1 minio_deploy\ $1
-}
-minikube_minio_url()
-{
-	minikube --profile $1 -n minio service --url minio
 }
 velero_backup()
 {


### PR DESCRIPTION
- Fixes #31 
- Includes `hack/minikube-ramen.sh` from https://github.com/RamenDR/ramen/pull/473
- Expects object name prefix ends in `velero/` #32 
- Expects initial velero backup name is `0`
- Groups Shio demo commands into routines:
```
infra_deploy
infra_undeploy
velero_secret_kubectl
velero_secret_deploy
velero_secret_undeploy
app_deploy
app_kube_object_list
app_undeploy
vrg_deploy
vrg_finalizer0_remove
vrg_get
app_protect
app_unprotect
app_recover
s3_objects_list
app_s3_object_name_prefix
app_s3_object_name_prefix_velero
app_s3_objects_delete
app_protection_info
app_recovery_info
velero_kube_objects_list
velero_kube_objects_undeploy
```