### PR TITLE
Velero driver: Append a "directory" to object name prefix so that it "contains" no "directories" and is considered valid

### DIFF
--- a/controllers/kubeobjects.go
+++ b/controllers/kubeobjects.go
@@ -216,7 +216,8 @@ func restoreStatusProcess(
 	case velero.RestorePhaseInProgress:
 		return errors.New("temporary: restore" + string(restore.Status.Phase))
 	case velero.RestorePhaseFailed:
-		backupObjectPathName := "backups/" + backup.Name + "/" + backup.Name + ".tar.gz"
+		backupObjectPathName := backupLocation.Spec.StorageType.ObjectStorage.Prefix +
+			"backups/" + backup.Name + "/" + backup.Name + ".tar.gz"
 		if strings.HasPrefix(restore.Status.FailureReason,
 			"error downloading backup: error copying Backup to temp file: rpc error: "+
 				"code = Unknown desc = error getting object "+backupObjectPathName+": "+
@@ -495,7 +496,7 @@ func backupLocation(namespacedName types.NamespacedName, s3Url, bucketName, s3Ke
 			StorageType: velero.StorageType{
 				ObjectStorage: &velero.ObjectStorageLocation{
 					Bucket: bucketName,
-					Prefix: s3KeyPrefix,
+					Prefix: s3KeyPrefix + "velero/",
 				},
 			},
 			Config: map[string]string{


### PR DESCRIPTION
A velero backup storage location "containing" a "directory", e.g., `v1.PersistentVolume`, is considered invalid:
```sh
$ kubectl logs -nvelero deploy/velero
time="2022-07-09T10:03:57Z" level=info msg="Validating backup storage location" backup-storage-location=0 controller=backup-storage-location logSource="pkg/controller/backup_storage_location_controller.go:114"
time="2022-07-09T10:03:57Z" level=info msg="Backup storage location is invalid, marking as unavailable" backup-storage-location=0 controller=backup-storage-location logSource="pkg/controller/backup_storage_location_controller.go:117"
time="2022-07-09T10:03:57Z" level=error msg="Current backup storage locations available/unavailable/unknown: 0/1/0, Backup storage location \"0\" is unavailable: Backup store contains invalid top-level directories: [v1.PersistentVolume])" controller=backup-storage-location logSource="pkg/controller/backup_storage_location_controller.go:164"
```
This patch appends `velero/` to each backup storage location's object name prefix so that it "contains" no "directories" other than those velero creates, e.g., `backups` and `restores`.