### PR TITLE
add velero namespace as RamenConfig input (#39)

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -106,6 +106,9 @@ type RamenConfig struct {
 	// Defaults to 1.
 	MaxConcurrentReconciles int `json:",omitempty"`
 
+	// Velero namespace input
+	VeleroNamespaceName string `json:"veleroNamespaceName,omitempty"`
+
 	// dr-cluster operator deployment/undeployment automation configuration
 	DrClusterOperator struct {
 		// dr-cluster operator deployment/undeployment automation enabled

--- a/config/samples/ramendr_v1alpha1_ramenconfig.yaml
+++ b/config/samples/ramendr_v1alpha1_ramenconfig.yaml
@@ -31,3 +31,4 @@ drClusterOperator:
   catalogSourceName: ramen-catalog
   catalogSourceNamespaceName: ramen-system
   clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1
+veleroNamespaceName: "openshift-adp"


### PR DESCRIPTION
**add velero namespace as RamenConfig input (#39)**
Add field `VeleroNamespaceName` to RamenConfigMap to override default "velero" namespace that Velero uses.

**Addresses:**
#39 