### PR TITLE
add velero secret name to Ramen ConfigMap (#48)

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -91,6 +91,9 @@ type KubeObjectProtection struct {
 	//+optional
 	// Disabled is used to disable KubeObjectProtection usage in Ramen.
 	Disabled *bool `json:"disabled,omitempty"`
+
+	//+optional
+	VeleroSecretName string `json:"veleroSecretName,omitempty"`
 }
 
 //+kubebuilder:object:root=true


### PR DESCRIPTION
- add new field to Ramen ConfigMap.KubeObjectProtection struct: VeleroSecretName
- Velero needs credentials to be able to log into a S3 store, but the Secret Ramen looks for used a hard-coded name that may not be appropriate for all environments.
- use the secret appropriate for your system by using specifying it in Ramen ConfigMap.KubeObjectProtection.VeleroSecretName=yourSecretName
- note that the Secret should use key "aws" and specify login/password credentials within that struct

Signed-off-by: Travis Janssen <travis.janssen@ibm.com>

----------

Addresses #48. Example secret setup for S3, along with Ramen ConfigMap:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: s3secret
  namespace: velero
type: Opaque
stringData:
  aws: |
    [default]
    AWS_ACCESS_KEY_ID: yourAccessKeyHere
    AWS_SECRET_ACCESS_KEY: yourSecretAccessKeyHere
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata: 
  name: ramen-dr-cluster-operator-config
  namespace: ramen-system
data:
  ramen_manager_config.yaml: |
    // data omitted for clarity
    kubeObjectProtection:
      veleroSecretName: s3secret
```