### PR TITLE
Cherry-pick latest Ramen fixes

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -84,6 +84,26 @@ const (
 	ReasonNotStarted  = "NotStarted"
 )
 
+type ProgressionStatus string
+
+const (
+	ProgressionCompleted            = ProgressionStatus("Completed")
+	ProgressionCreatingMW           = ProgressionStatus("CreatingMW")
+	ProgressionUpdatingPlRule       = ProgressionStatus("UpdatingPlRule")
+	ProgressionWaitForReadiness     = ProgressionStatus("WaitForReadiness")
+	ProgressionCleaningUp           = ProgressionStatus("Cleaning Up")
+	ProgressionFailingOverToCluster = ProgressionStatus("FailingOverToCluster")
+	ProgressionPreparingFinalSync   = ProgressionStatus("PreparingFinalSync")
+	ProgressionClearingPlRule       = ProgressionStatus("ClearingPlRule")
+	ProgressionRunningFinalSync     = ProgressionStatus("RunningFinalSync")
+	ProgressionFinalSyncComplete    = ProgressionStatus("FinalSyncComplete")
+	ProgressionMovingToSecondary    = ProgressionStatus("MovingToSecondary")
+	ProgressionWaitingForPVRestore  = ProgressionStatus("WaitingForPVRestore")
+	ProgressionUpdatedPlRule        = ProgressionStatus("UpdatedPlRule")
+	ProgressionEnsuringVolSyncSetup = ProgressionStatus("EnsuringVolSyncSetup")
+	ProgressionSettingupVolsyncDest = ProgressionStatus("SettingUpVolSyncDest")
+)
+
 // DRPlacementControlSpec defines the desired state of DRPlacementControl
 type DRPlacementControlSpec struct {
 	// PlacementRef is the reference to the PlacementRule used by DRPC
@@ -144,7 +164,7 @@ type DRPlacementControlStatus struct {
 	Phase              DRState                 `json:"phase,omitempty"`
 	ActionStartTime    *metav1.Time            `json:"actionStartTime,omitempty"`
 	ActionDuration     *metav1.Duration        `json:"actionDuration,omitempty"`
-	Progression        string                  `json:"progression,omitempty"`
+	Progression        ProgressionStatus       `json:"progression,omitempty"`
 	PreferredDecision  plrv1.PlacementDecision `json:"preferredDecision,omitempty"`
 	Conditions         []metav1.Condition      `json:"conditions,omitempty"`
 	ResourceConditions VRGConditions           `json:"resourceConditions,omitempty"`

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -39,7 +39,7 @@ func (d *DRPCInstance) EnsureVolSyncReplicationSetup(homeCluster string) error {
 
 func (d *DRPCInstance) ensureVolSyncReplicationCommon(srcCluster string) error {
 	// Make sure we have Source and Destination VRGs - Source should already have been created at this point
-	d.setProgression("EnsuringVolSyncSetup")
+	d.setProgression(rmn.ProgressionEnsuringVolSyncSetup)
 
 	const maxNumberOfVRGs = 2
 	if len(d.vrgs) != maxNumberOfVRGs {
@@ -91,7 +91,7 @@ func (d *DRPCInstance) ensureVolSyncReplicationCommon(srcCluster string) error {
 }
 
 func (d *DRPCInstance) ensureVolSyncReplicationDestination(srcCluster string) error {
-	d.setProgression("SettingUpVolSyncDest")
+	d.setProgression(rmn.ProgressionSettingupVolsyncDest)
 
 	srcVRG, found := d.vrgs[srcCluster]
 	if !found {

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -35,6 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// We have seen that the valid errors from the s3 servers take up to 2 minutes.
+// Let the timeout be greater than that.
+var s3Timeout = time.Second * 125
 
 // Example usage:
 // func example_code() {
@@ -385,7 +390,10 @@ func (s *s3ObjectStore) UploadObject(key string,
 			bucket, key, err)
 	}
 
-	if _, err := s.uploader.Upload(&s3manager.UploadInput{
+	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(s3Timeout))
+	defer cancel()
+
+	if _, err := s.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
 		Bucket: &bucket,
 		Key:    &key,
 		Body:   encodedUploadContent,
@@ -476,8 +484,11 @@ func (s *s3ObjectStore) ListKeys(keyPrefix string) (
 
 	bucket := s.s3Bucket
 
+	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(s3Timeout))
+	defer cancel()
+
 	for gotAllObjects := false; !gotAllObjects; {
-		result, err := s.client.ListObjectsV2(&s3.ListObjectsV2Input{
+		result, err := s.client.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
 			Bucket:            &bucket,
 			Prefix:            &keyPrefix,
 			ContinuationToken: nextContinuationToken,
@@ -499,7 +510,7 @@ func (s *s3ObjectStore) ListKeys(keyPrefix string) (
 		}
 	}
 
-	return
+	return keys, nil
 }
 
 // DownloadObject downloads an object from the bucket with the given key,
@@ -521,7 +532,10 @@ func (s *s3ObjectStore) DownloadObject(key string,
 	bucket := s.s3Bucket
 	writerAt := &aws.WriteAtBuffer{}
 
-	if _, err := s.downloader.Download(writerAt, &s3.GetObjectInput{
+	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(s3Timeout))
+	defer cancel()
+
+	if _, err := s.downloader.DownloadWithContext(ctx, writerAt, &s3.GetObjectInput{
 		Bucket: &bucket,
 		Key:    &key,
 	}); err != nil {
@@ -574,7 +588,10 @@ func (s *s3ObjectStore) DeleteObjects(keyPrefix string) (
 		}
 	}
 
-	if err = s.batchDeleter.Delete(aws.BackgroundContext(), &s3manager.DeleteObjectsIterator{
+	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(s3Timeout))
+	defer cancel()
+
+	if err = s.batchDeleter.Delete(ctx, &s3manager.DeleteObjectsIterator{
 		Objects: delObjects,
 	}); err != nil {
 		return fmt.Errorf("unable to DeleteObjects "+

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -314,9 +314,14 @@ func (v *VRGInstance) preparePVCForVRDeletion(pvc *corev1.PersistentVolumeClaim,
 	// For Sync mode, we don't want to set the retention policy to delete as
 	// both the primary and the secondary VRG map to the same volume. The only
 	// state where a delete retention policy is required for the sync mode is
-	// when the VRG is primary.
-	if !(v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary &&
-		v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled) {
+	// when the VRG is primary. Furthermore, we need to clear the PV claimRef
+	// in order for the PV to go to the Available status phase.
+	if v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary &&
+		v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+		if err := v.clearPVClaimRefMembers(pvc); err != nil {
+			return err
+		}
+	} else {
 		if err := v.undoPVRetentionForPVC(*pvc, log); err != nil {
 			return err
 		}
@@ -364,6 +369,34 @@ func (v *VRGInstance) retainPVForPVC(pvc corev1.PersistentVolumeClaim, log logr.
 
 		return fmt.Errorf("failed to update PersistentVolume resource (%s) reclaim policy for"+
 			" PersistentVolumeClaim resource (%s/%s) belonging to VolumeReplicationGroup (%s/%s), %w",
+			pvc.Spec.VolumeName, pvc.Namespace, pvc.Name, v.instance.Namespace, v.instance.Name, err)
+	}
+
+	return nil
+}
+
+func (v *VRGInstance) clearPVClaimRefMembers(pvc *corev1.PersistentVolumeClaim) error {
+	// Get PV bound to PVC
+	pv := &corev1.PersistentVolume{}
+	pvObjectKey := client.ObjectKey{
+		Name: pvc.Spec.VolumeName,
+	}
+
+	if err := v.reconciler.Get(v.ctx, pvObjectKey, pv); err != nil {
+		return fmt.Errorf("failed to get PV resource (%s) for"+
+			" PVC resource (%s/%s) belonging to VRG (%s/%s), %w",
+			pvc.Spec.VolumeName, pvc.Namespace, pvc.Name, v.instance.Namespace, v.instance.Name, err)
+	}
+
+	if pv.Spec.ClaimRef != nil {
+		pv.Spec.ClaimRef.UID = ""
+		pv.Spec.ClaimRef.ResourceVersion = ""
+		pv.Spec.ClaimRef.APIVersion = ""
+	}
+
+	if err := v.reconciler.Update(v.ctx, pv); err != nil {
+		return fmt.Errorf("failed to update PV resource (%s) claimRef for"+
+			" PVC resource (%s/%s) belonging to VRG (%s/%s), %w",
 			pvc.Spec.VolumeName, pvc.Namespace, pvc.Name, v.instance.Namespace, v.instance.Name, err)
 	}
 


### PR DESCRIPTION
```sh
$ git cherry-pick b6521ea..c6758ae
[main e9e3f7a] creating progressionstatus conditions as type
 Author: rakeshgm <rakeshgm@redhat.com>
 Date: Fri Aug 5 16:12:30 2022 +0530
 3 files changed, 41 insertions(+), 21 deletions(-)
[main a66e574] s3utils: add deadline to s3 operations
 Author: Raghavendra Talur <raghavendra.talur@gmail.com>
 Date: Thu Aug 4 14:24:02 2022 -0400
 1 file changed, 22 insertions(+), 5 deletions(-)
[main 7aa9c36] MetroDR: clear PV ClaimRef on secondary PVC deletion and put back the ClaimRef on restore
 Author: Benamar Mekhissi <bmekhiss@redhat.com>
 Date: Tue Aug 9 10:02:51 2022 -0400
 1 file changed, 36 insertions(+), 3 deletions(-)
 ```