### PR TITLE
vrg: delete velero kube objects then s3 objects

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -691,6 +691,13 @@ func (v *VRGInstance) processForDeletion() (ctrl.Result, error) {
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	result := ctrl.Result{}
+	if err := v.kubeObjectsProtectionDelete(&result); err != nil {
+		v.log.Info("Kube objects protection deletion failed", "error", err)
+
+		return result, err
+	}
+
 	if v.instance.Spec.ReplicationState == ramendrv1alpha1.Primary {
 		if err := v.deleteClusterDataInS3Stores(v.log); err != nil {
 			v.log.Info("Requeuing due to failure in deleting cluster data from S3 stores",
@@ -698,13 +705,6 @@ func (v *VRGInstance) processForDeletion() (ctrl.Result, error) {
 
 			return ctrl.Result{Requeue: true}, nil
 		}
-	}
-
-	result := ctrl.Result{}
-	if err := v.kubeObjectsProtectionDelete(&result); err != nil {
-		v.log.Info("Kube objects protection deletion failed", "error", err)
-
-		return result, err
 	}
 
 	if err := v.removeFinalizer(vrgFinalizerName); err != nil {


### PR DESCRIPTION
After testing PR #64, I noticed velero Kube objects were absent as expected, but velero s3 objects were present:
```sh
$ mc tree cluster1
cluster1
└─ bucket
   └─ asdf
      └─ bb
         └─ kube-objects
            └─ 0
               └─ velero
                  └─ backups
                     └─ asdf--bb--0----minio-on-cluster1

$ mc ls cluster1 --recursive
[2022-08-16 16:54:46 PDT]    29B bucket/asdf/bb/kube-objects/0/velero/backups/asdf--bb--0----minio-on-cluster1/asdf--bb--0----minio-on-cluster1-csi-volumesnapshotcontents.json.gz
[2022-08-16 16:54:46 PDT]    29B bucket/asdf/bb/kube-objects/0/velero/backups/asdf--bb--0----minio-on-cluster1/asdf--bb--0----minio-on-cluster1-csi-volumesnapshots.json.gz
[2022-08-16 16:54:46 PDT] 4.6KiB bucket/asdf/bb/kube-objects/0/velero/backups/asdf--bb--0----minio-on-cluster1/asdf--bb--0----minio-on-cluster1-logs.gz
[2022-08-16 16:54:46 PDT]    29B bucket/asdf/bb/kube-objects/0/velero/backups/asdf--bb--0----minio-on-cluster1/asdf--bb--0----minio-on-cluster1-podvolumebackups.json.gz
[2022-08-16 16:54:46 PDT]   347B bucket/asdf/bb/kube-objects/0/velero/backups/asdf--bb--0----minio-on-cluster1/asdf--bb--0----minio-on-cluster1-resource-list.json.gz
[2022-08-16 16:54:46 PDT]    29B bucket/asdf/bb/kube-objects/0/velero/backups/asdf--bb--0----minio-on-cluster1/asdf--bb--0----minio-on-cluster1-volumesnapshots.json.gz
[2022-08-16 16:54:46 PDT]  11KiB bucket/asdf/bb/kube-objects/0/velero/backups/asdf--bb--0----minio-on-cluster1/asdf--bb--0----minio-on-cluster1.tar.gz
[2022-08-16 16:54:46 PDT] 2.3KiB bucket/asdf/bb/kube-objects/0/velero/backups/asdf--bb--0----minio-on-cluster1/velero-backup.json
```

It seems the right order is Kube objects first, then s3 objects, because the Kube objects can create s3 objects.  This is the order for the regular backups.  Velero restore Kube objects are not deleted except at VRG primary deletion.