### PR TITLE
log download object routine

### DIFF
--- a/controllers/protectedvolumereplicationgrouplist_controller.go
+++ b/controllers/protectedvolumereplicationgrouplist_controller.go
@@ -148,6 +148,7 @@ func (s *ProtectedVolumeReplicationGroupListInstance) getVrgContentsFromS3(prefi
 			// download VRGs
 			prefixInS3 := fmt.Sprintf("%s/%s/", namespace, vrgName)
 
+			s.log.Info("downloadVRGs", "namespace", namespace, "vrg", vrgName, "prefix", prefixInS3)
 			vrgs, err := DownloadVRGs(objectStore, prefixInS3)
 			if err != nil {
 				return vrgsAll, fmt.Errorf("error during DownloadVRGs on '%s': %w", prefixInS3, err)

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -34,6 +34,7 @@ import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -172,6 +173,7 @@ func (s3ObjectStoreGetter) ObjectStore(ctx context.Context,
 		s3Bucket:     s3StoreProfile.S3Bucket,
 		callerTag:    callerTag,
 		name:         s3ProfileName,
+		log:          log,
 	}
 
 	return s3Conn, s3StoreProfile, nil
@@ -210,6 +212,7 @@ type s3ObjectStore struct {
 	s3Bucket     string
 	callerTag    string
 	name         string
+	log          logr.Logger
 }
 
 // CreateBucket creates the given bucket; does not return an error if the bucket
@@ -462,8 +465,13 @@ func DownloadTypedObjects(s ObjectStorer, keyPrefix string, objectsPointer inter
 	objects := reflect.MakeSlice(reflect.SliceOf(objectType),
 		len(keys), len(keys))
 
+	log := ctrl.Log
+	log.Info("s3 download typed objects", "keys", keys, "objectsValue", objectsValue, "objectType", objectType)
 	for i := range keys {
 		objectReceiver := objects.Index(i).Addr().Interface()
+
+		log.Info("s3 download typed object", "i", i, "key", keys[i], "objectReceiver", objectReceiver)
+
 		if err := s.DownloadObject(keys[i], objectReceiver); err != nil {
 			return fmt.Errorf("unable to DownloadObject of key %s, %w",
 				keys[i], err)
@@ -544,10 +552,22 @@ func (s *s3ObjectStore) DownloadObject(key string,
 	}
 
 	gzReader, err := gzip.NewReader(bytes.NewReader(writerAt.Bytes()))
-	if err != nil && !errorswrapper.Is(err, io.EOF) {
-		return fmt.Errorf("failed to unzip data of %s:%s, %w",
-			bucket, key, err)
+	if err != nil {
+		if !errorswrapper.Is(err, io.EOF) {
+			return fmt.Errorf("failed to unzip data of %s:%s, %w",
+				bucket, key, err)
+		}
+
+		s.log.Info("s3 download object end-of-file", "error", err)
 	}
+
+	s.log.Info("s3 download object decode",
+		"bucket", bucket,
+		"key", key,
+		"downloadContent", downloadContent,
+		"writerAt", writerAt,
+		"gzReader", gzReader,
+	)
 
 	if err := json.NewDecoder(gzReader).Decode(downloadContent); err != nil {
 		return fmt.Errorf("failed to decode json decoder of %s:%s, %w",


### PR DESCRIPTION
Log some things in effort to debug this:
```sh
2022-12-10T14:31:55.265Z	DEBUG	events	record/event.go:311	Normal	{"object": {"kind":"VolumeReplicationGroup","namespace":"rackf-app813-ns","name":"rackf-app813-ns","uid":"88df43cc-1558-4f0a-a727-0684d40e896d","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"21349775"}, "reason": "SecondaryVRGProcessSuccess", "message": "Secondary Success"}
2022-12-10T14:31:55.266Z	INFO	controllers.VolumeReplicationGroup.vrginstance	controllers/vrg_kubeobjects.go:504	Kube object protection	{"VolumeReplicationGroup": "rackf-app813-ns/rackf-app813-ns", "State": "secondary", "disabled": true, "VRG": true, "configMap": true, "for": "status"}
2022-12-10T14:31:55.266Z	INFO	controllers.VolumeReplicationGroup.vrginstance	controllers/volumereplicationgroup_controller.go:1041	VRG object unprotected	{"VolumeReplicationGroup": "rackf-app813-ns/rackf-app813-ns", "State": "secondary"}
2022-12-10T14:31:55.266Z	INFO	controllers.protectedvolumereplicationgrouplist	controllers/protectedvolumereplicationgrouplist_controller.go:104	downloaded VRG with name 'rackf-app16-ns' in namespace 'rackf-app16-ns'	{"name": "s3bucketview"}
2022-12-10T14:31:55.269Z	INFO	controllers.protectedvolumereplicationgrouplist	controllers/protectedvolumereplicationgrouplist_controller.go:104	downloaded VRG with name 'rackf-app17-ns' in namespace 'rackf-app17-ns'	{"name": "s3bucketview"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x280 pc=0x729a6e]

goroutine 737 [running]:
compress/gzip.(*Reader).Read(0x0, {0xc00219a400, 0x0, 0xc0010ff258})
	/usr/local/go/src/compress/gzip/gunzip.go:247 +0x2e
encoding/json.(*Decoder).refill(0xc00054ca00)
	/usr/local/go/src/encoding/json/stream.go:165 +0x17f
encoding/json.(*Decoder).readValue(0xc00054ca00)
	/usr/local/go/src/encoding/json/stream.go:140 +0xbb
encoding/json.(*Decoder).Decode(0xc00054ca00, {0x1b542e0, 0xc001355b80})
	/usr/local/go/src/encoding/json/stream.go:63 +0x78
github.com/ramendr/ramen/controllers.(*s3ObjectStore).DownloadObject(0xc000406fc0, {0xc001f33180, 0x3f}, {0x1b542e0, 0xc001355b80})
	/workspace/controllers/s3utils.go:552 +0x625
github.com/ramendr/ramen/controllers.DownloadTypedObjects({0x1ed1778, 0xc000406fc0}, {0xc00128c820, 0x1e}, {0x18375c0, 0xc001286f78})
	/workspace/controllers/s3utils.go:467 +0x354
github.com/ramendr/ramen/controllers.DownloadVRGs(...)
	/workspace/controllers/s3utils.go:438
github.com/ramendr/ramen/controllers.(*ProtectedVolumeReplicationGroupListInstance).getVrgContentsFromS3(0xc0010ffc00, {0xc000c46000, 0x49, 0x80}, {0x1ed1778, 0xc000406fc0})
	/workspace/controllers/protectedvolumereplicationgrouplist_controller.go:151 +0x31a
github.com/ramendr/ramen/controllers.(*ProtectedVolumeReplicationGroupListReconciler).Reconcile(0xc000a92340, {0x1ed14d8, 0xc001445470}, {{{0x0, 0x1abc5c0}, {0xc00140a6d0, 0x30}}})
	/workspace/controllers/protectedvolumereplicationgrouplist_controller.go:104 +0x61a
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc0005a24d0, {0x1ed14d8, 0xc0014453e0}, {{{0x0, 0x1abc5c0}, {0xc00140a6d0, 0x413b94}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:114 +0x26f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0005a24d0, {0x1ed1430, 0xc000a922c0}, {0x19bcf40, 0xc0020898a0})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:311 +0x33e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0005a24d0, {0x1ed1430, 0xc000a922c0})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:266 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:223 +0x357

```
